### PR TITLE
Kakao API connection

### DIFF
--- a/Naenio.xcodeproj/project.pbxproj
+++ b/Naenio.xcodeproj/project.pbxproj
@@ -87,6 +87,7 @@
 		9B085F192879991600DE8E60 /* NaenioUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = NaenioUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		9B085F1D2879991600DE8E60 /* NaenioUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NaenioUITests.swift; sourceTree = "<group>"; };
 		9B085F1F2879991600DE8E60 /* NaenioUITestsLaunchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NaenioUITestsLaunchTests.swift; sourceTree = "<group>"; };
+		9B811653288AD72700099F29 /* KeyValue.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = KeyValue.swift; sourceTree = "<group>"; };
 		9BF00BF2287AC72800F08035 /* Naenio.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Naenio.entitlements; sourceTree = "<group>"; };
 		9BF00BF6287AC95A00F08035 /* AppleLoginManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppleLoginManager.swift; sourceTree = "<group>"; };
 		9BF00C0A287ACFA900F08035 /* LoginRequestInformation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginRequestInformation.swift; sourceTree = "<group>"; };
@@ -177,6 +178,7 @@
 		4CC296DC288054C0001950A2 /* Constants */ = {
 			isa = PBXGroup;
 			children = (
+				9B811653288AD72700099F29 /* KeyValue.swift */,
 				4CC296DF288055FD001950A2 /* HeaderInformation.swift */,
 				4C4B13422883D88A006044B0 /* HttpResponseCode.swift */,
 				9C3309D42888ED52000C592F /* KeyValue.swift */,

--- a/Naenio/Sources/LogIn/Apple/AppleLoginManager.swift
+++ b/Naenio/Sources/LogIn/Apple/AppleLoginManager.swift
@@ -29,7 +29,7 @@ class AppleLoginManager{
             }
             
             // TODO: LoginRequestInformation May contain authorization codes
-            let loginInfo = LoginRequestInformation(accessToken: stringToken)
+            let loginInfo = LoginRequestInformation(authToken: stringToken, authServiceType: "APPLE")
             let userInfo = try submitUserInformationToServer(with: loginInfo)
             
             return .success(userInfo)
@@ -42,7 +42,7 @@ class AppleLoginManager{
     /// API 콜을 요청하는 내부 메소드입니다
     private func submitUserInformationToServer(with info: LoginRequestInformation) throws -> UserInformation {
         // let userInfo = API.request(with: info)
-        let mockInfo = UserInformation(name: "", id: "")
+        let mockInfo = UserInformation(token: "")
         return mockInfo
     }
 }

--- a/Naenio/Sources/LogIn/Kakao/KakaoLoginManager.swift
+++ b/Naenio/Sources/LogIn/Kakao/KakaoLoginManager.swift
@@ -8,25 +8,27 @@
 import KakaoSDKAuth
 import KakaoSDKCommon
 import KakaoSDKUser
+import RxSwift
 
 /// 카카오 서버에서 받아온 인증 정보를 네니오 서버에 보내기 위한 작업을 하는 클래스입니다
 class KakaoLoginManager {
-    func requestLoginToServer(with result: OAuthToken) -> Result<UserInformation, Error> {
-        do {
-            let token = result.accessToken
-            let loginInfo = LoginRequestInformation(authToken: token, authServiceType: "KAKAO")
-            let userInfo = try submitUserInformationToServer(with: loginInfo)
-            
-            return .success(userInfo)
-        }
-        catch let error {
-            return .failure(error)
-        }
+    func requestLoginToServer(with result: OAuthToken) -> Single<UserInformation> {
+        let token = result.accessToken
+        let loginInfo = LoginRequestInformation(authToken: token, authServiceType: "KAKAO")
+        
+        return submitUserInformationToServer(with: loginInfo)
     }
     
-    private func submitUserInformationToServer(with info: LoginRequestInformation) throws -> UserInformation {
-        // let userInfo = API.request(with: info)
-        let mockInfo = UserInformation(name: "", id: "")
-        return mockInfo
+    private func submitUserInformationToServer(with info: LoginRequestInformation) -> Single<UserInformation> {
+        let sequence = NaenioAPI.login(info)
+            .request()
+            .map { response -> UserInformation in
+                let data = response.data
+                let decoded = try NaenioAPI.jsonDecoder.decode(UserInformation.self, from: data)
+                
+                return decoded
+            }
+        
+        return sequence
     }
 }

--- a/Naenio/Sources/LogIn/Kakao/KakaoLoginManager.swift
+++ b/Naenio/Sources/LogIn/Kakao/KakaoLoginManager.swift
@@ -14,7 +14,7 @@ class KakaoLoginManager {
     func requestLoginToServer(with result: OAuthToken) -> Result<UserInformation, Error> {
         do {
             let token = result.accessToken
-            let loginInfo = LoginRequestInformation(accessToken: token)
+            let loginInfo = LoginRequestInformation(authToken: token, authServiceType: "KAKAO")
             let userInfo = try submitUserInformationToServer(with: loginInfo)
             
             return .success(userInfo)

--- a/Naenio/Sources/LogIn/Kakao/SignInWithKakaoButton.swift
+++ b/Naenio/Sources/LogIn/Kakao/SignInWithKakaoButton.swift
@@ -29,6 +29,9 @@ struct SignInWithKakaoButton: View {
                     .fill(.yellow)
             )
         }
+        .onOpenURL { url in
+            _ = AuthController.handleOpenUrl(url: url)
+        }
     }
     
     init(onCompletion: @escaping ((Result<OAuthToken, Error>) -> Void)) {

--- a/Naenio/Sources/LogIn/Kakao/SignInWithKakaoButton.swift
+++ b/Naenio/Sources/LogIn/Kakao/SignInWithKakaoButton.swift
@@ -17,7 +17,7 @@ struct SignInWithKakaoButton: View {
     
     var body: some View {
         Button(action: {
-            viewModel.requestLoginToKakaoServer(onCompletion)
+            viewModel.login(onCompletion)
         }) {
             HStack {
                 Text("카카오로 로그인")

--- a/Naenio/Sources/LogIn/Kakao/SignInWithKakaoButtonViewModel.swift
+++ b/Naenio/Sources/LogIn/Kakao/SignInWithKakaoButtonViewModel.swift
@@ -11,8 +11,12 @@ import KakaoSDKCommon
 import Combine
 
 class SignInWithKakaoButtonViewModel {
+    func login(_ completion: @escaping (Result<OAuthToken, Error>) -> Void) {
+        requestLoginToKakaoServer(completion)
+    }
+    
     /// - Returns: `Result` type을 리턴함.  Kakao SDK 고유 타입인 `OAuthToken`와 Swift native type `Error`를 포함한다.
-    func requestLoginToKakaoServer(_ completion: @escaping (Result<OAuthToken, Error>) -> Void) {
+    private func requestLoginToKakaoServer(_ completion: @escaping (Result<OAuthToken, Error>) -> Void) {
         if (UserApi.isKakaoTalkLoginAvailable()) {
             UserApi.shared.loginWithKakaoTalk {(oauthToken, error) in
                 if let error = error {

--- a/Naenio/Sources/LogIn/LoginTestViewModel.swift
+++ b/Naenio/Sources/LogIn/LoginTestViewModel.swift
@@ -8,6 +8,7 @@
 import SwiftUI
 import AuthenticationServices
 import KakaoSDKAuth
+import RxSwift
 
 class LoginTestViewModel: ObservableObject {
     // Dependencies
@@ -17,6 +18,9 @@ class LoginTestViewModel: ObservableObject {
     // Published vars
     /// 로그인 루틴 처리 상태를 표시
     @Published var status: Status = .waiting
+    
+    // Private vars
+    private let bag = DisposeBag()
     
     // MARK: - For apple
     func handleAppleLoginResult(result: Result<ASAuthorization, Error>) {
@@ -52,15 +56,29 @@ class LoginTestViewModel: ObservableObject {
     }
     
     private func requestKakaoLoginToServer(with result: OAuthToken) {
-        switch kakaoLoginManager.requestLoginToServer(with: result) {
-        case .success(let user):
-            print(user)
-            // Save(user)
-            
-            status = .done
-        case .failure(let error):
-            status = .fail(with: error)
-        }
+        kakaoLoginManager.requestLoginToServer(with: result)
+            .subscribe(on: ConcurrentDispatchQueueScheduler(qos: .utility))
+            .subscribe(
+                onSuccess: { [weak self] userInfo in
+                    guard let self = self else { return }
+                    // Save(userInfo)
+                    DispatchQueue.main.async {
+                        self.status = .done
+                    }
+                },
+                onFailure: { [weak self] error in
+                    guard let self = self else { return }
+                    DispatchQueue.main.async {
+                        self.status = .fail(with: error)
+                    }
+                },
+                onDisposed: {
+#if DEBUG
+                    print("disposed")
+#endif
+                }
+            )
+            .disposed(by: bag)
     }
     
     init(_ appleLoginManager: AppleLoginManager = AppleLoginManager(),
@@ -68,6 +86,12 @@ class LoginTestViewModel: ObservableObject {
         self.appleLoginManager = appleLoginManager
         self.kakaoLoginManager = kakaoLoginManager
     }
+    
+#if DEBUG
+    deinit {
+        print("\(#function) deinit")
+    }
+#endif
 }
 
 extension LoginTestViewModel {

--- a/Naenio/Sources/LogIn/LoginTestViewModel.swift
+++ b/Naenio/Sources/LogIn/LoginTestViewModel.swift
@@ -89,7 +89,7 @@ class LoginTestViewModel: ObservableObject {
     
 #if DEBUG
     deinit {
-        print("\(#function) deinit")
+        print("LoginTestViewModel deinit")
     }
 #endif
 }

--- a/Naenio/Sources/LogIn/Models/LoginRequestInformation.swift
+++ b/Naenio/Sources/LogIn/Models/LoginRequestInformation.swift
@@ -8,5 +8,6 @@
 import Foundation
 
 struct LoginRequestInformation: ModelType {
-    let accessToken: String
+    let authToken: String
+    let authServiceType: String
 }

--- a/Naenio/Sources/LogIn/Models/UserInformation.swift
+++ b/Naenio/Sources/LogIn/Models/UserInformation.swift
@@ -9,6 +9,5 @@ import Foundation
 
 // !!!: Temporary
 struct UserInformation: Codable {
-    let name: String
-    let id: String
+    let token: String
 }


### PR DESCRIPTION
### 구현 사항
- Kakao login을 naenio 서버와 연동했습니다.
- Kakao login에서 Moya 구현에 맞춰 `Result` 타입을 리턴하도록 구현되어있던 네트워크 메소드들을 `Single<Userinformation>`을 리턴하도록 수정했습니다.
