### PR TITLE
[Networking] 대댓글 조회 API 연결 및 대댓글 작성 APi 확인 완료

### DIFF
--- a/Naenio.xcodeproj/project.pbxproj
+++ b/Naenio.xcodeproj/project.pbxproj
@@ -19,6 +19,10 @@
 		4C4B133F2883CD32006044B0 /* ModelType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C4B133E2883CD32006044B0 /* ModelType.swift */; };
 		4C4B13432883D88A006044B0 /* HttpResponseCode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C4B13422883D88A006044B0 /* HttpResponseCode.swift */; };
 		4C4B134528847640006044B0 /* NaenioAPI+Request.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C4B134428847640006044B0 /* NaenioAPI+Request.swift */; };
+		4C7ECFEC28B50FDA006C1763 /* ignored in Resources */ = {isa = PBXBuildFile; fileRef = 4C7ECFEB28B50FDA006C1763 /* ignored */; };
+		4C7ECFEE28B5100B006C1763 /* KeyValue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C7ECFED28B5100B006C1763 /* KeyValue.swift */; };
+		4C7ECFF028B51755006C1763 /* CommentRepliesRequestModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C7ECFEF28B51755006C1763 /* CommentRepliesRequestModel.swift */; };
+		4C7ECFF228B518FE006C1763 /* CommentRepliesResponseModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C7ECFF128B518FE006C1763 /* CommentRepliesResponseModel.swift */; };
 		4CA47BCA2890344400D300A7 /* .swiftlint.yml in Resources */ = {isa = PBXBuildFile; fileRef = 4CA47BC92890344400D300A7 /* .swiftlint.yml */; };
 		4CA59E9128AD504F002C0FA9 /* ThemeRequestModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CA59E9028AD504F002C0FA9 /* ThemeRequestModel.swift */; };
 		4CA59EA128AE884E002C0FA9 /* CommentPostResponseModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CA59EA028AE884E002C0FA9 /* CommentPostResponseModel.swift */; };
@@ -57,7 +61,6 @@
 		9B085F142879991600DE8E60 /* LoginTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B085F132879991600DE8E60 /* LoginTests.swift */; };
 		9B085F1E2879991600DE8E60 /* NaenioUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B085F1D2879991600DE8E60 /* NaenioUITests.swift */; };
 		9B085F202879991600DE8E60 /* NaenioUITestsLaunchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B085F1F2879991600DE8E60 /* NaenioUITestsLaunchTests.swift */; };
-		9B19A1D528AF1E330072DEDA /* KeyValue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B19A1D328AF1E330072DEDA /* KeyValue.swift */; };
 		9B19A1DD28AF7B1E0072DEDA /* AvailableNicknameResponseModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B19A1DC28AF7B1E0072DEDA /* AvailableNicknameResponseModel.swift */; };
 		9B244070289E8DC30060A244 /* View + Exetension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B24406F289E8DC30060A244 /* View + Exetension.swift */; };
 		9B244073289E9AA10060A244 /* VotesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B244072289E9AA10060A244 /* VotesView.swift */; };
@@ -201,6 +204,10 @@
 		4C4B133E2883CD32006044B0 /* ModelType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelType.swift; sourceTree = "<group>"; };
 		4C4B13422883D88A006044B0 /* HttpResponseCode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HttpResponseCode.swift; sourceTree = "<group>"; };
 		4C4B134428847640006044B0 /* NaenioAPI+Request.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NaenioAPI+Request.swift"; sourceTree = "<group>"; };
+		4C7ECFEB28B50FDA006C1763 /* ignored */ = {isa = PBXFileReference; lastKnownFileType = folder; path = ignored; sourceTree = "<group>"; };
+		4C7ECFED28B5100B006C1763 /* KeyValue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyValue.swift; sourceTree = "<group>"; };
+		4C7ECFEF28B51755006C1763 /* CommentRepliesRequestModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommentRepliesRequestModel.swift; sourceTree = "<group>"; };
+		4C7ECFF128B518FE006C1763 /* CommentRepliesResponseModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommentRepliesResponseModel.swift; sourceTree = "<group>"; };
 		4CA47BC92890344400D300A7 /* .swiftlint.yml */ = {isa = PBXFileReference; lastKnownFileType = text.yaml; path = .swiftlint.yml; sourceTree = "<group>"; };
 		4CA59E9028AD504F002C0FA9 /* ThemeRequestModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemeRequestModel.swift; sourceTree = "<group>"; };
 		4CA59EA028AE884E002C0FA9 /* CommentPostResponseModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommentPostResponseModel.swift; sourceTree = "<group>"; };
@@ -242,8 +249,6 @@
 		9B085F192879991600DE8E60 /* NaenioUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = NaenioUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		9B085F1D2879991600DE8E60 /* NaenioUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NaenioUITests.swift; sourceTree = "<group>"; };
 		9B085F1F2879991600DE8E60 /* NaenioUITestsLaunchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NaenioUITestsLaunchTests.swift; sourceTree = "<group>"; };
-		9B19A1D328AF1E330072DEDA /* KeyValue.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = KeyValue.swift; sourceTree = "<group>"; };
-		9B19A1D428AF1E330072DEDA /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		9B19A1DC28AF7B1E0072DEDA /* AvailableNicknameResponseModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AvailableNicknameResponseModel.swift; sourceTree = "<group>"; };
 		9B24406F289E8DC30060A244 /* View + Exetension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View + Exetension.swift"; sourceTree = "<group>"; };
 		9B244072289E9AA10060A244 /* VotesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VotesView.swift; sourceTree = "<group>"; };
@@ -434,6 +439,7 @@
 		4CC296DC288054C0001950A2 /* Constants */ = {
 			isa = PBXGroup;
 			children = (
+				4C7ECFED28B5100B006C1763 /* KeyValue.swift */,
 				4CC296DF288055FD001950A2 /* HeaderInformation.swift */,
 				4C4B13422883D88A006044B0 /* HttpResponseCode.swift */,
 			);
@@ -601,7 +607,7 @@
 		9B085F012879991400DE8E60 /* Naenio */ = {
 			isa = PBXGroup;
 			children = (
-				9B19A1D228AF1E330072DEDA /* ignored */,
+				4C7ECFEB28B50FDA006C1763 /* ignored */,
 				9BF00BF2287AC72800F08035 /* Naenio.entitlements */,
 				9B085F082879991600DE8E60 /* Preview Content */,
 				9B085F2D287E353600DE8E60 /* Resources */,
@@ -686,16 +692,6 @@
 				4CC296D228804E88001950A2 /* Network */,
 			);
 			path = Utils;
-			sourceTree = "<group>";
-		};
-		9B19A1D228AF1E330072DEDA /* ignored */ = {
-			isa = PBXGroup;
-			children = (
-				9B19A1D328AF1E330072DEDA /* KeyValue.swift */,
-				9B19A1D428AF1E330072DEDA /* Info.plist */,
-			);
-			name = ignored;
-			path = ../../ignored;
 			sourceTree = "<group>";
 		};
 		9B19A1DB28AF7AFA0072DEDA /* Models */ = {
@@ -1157,6 +1153,8 @@
 				4CA59EA028AE884E002C0FA9 /* CommentPostResponseModel.swift */,
 				4CA59EA228AE8888002C0FA9 /* CommentType.swift */,
 				4CA59EAF28AEA3DF002C0FA9 /* CommentListRequestModel.swift */,
+				4C7ECFEF28B51755006C1763 /* CommentRepliesRequestModel.swift */,
+				4C7ECFF128B518FE006C1763 /* CommentRepliesResponseModel.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -1278,6 +1276,7 @@
 				9B3B6F10289BE3FA002A76A7 /* MockPostWroteList.json in Resources */,
 				9B3B6F11289BE3FA002A76A7 /* MockPostParticipatedList.json in Resources */,
 				9CCA2295289BB3CF00A2F9B0 /* MockPostList.json in Resources */,
+				4C7ECFEC28B50FDA006C1763 /* ignored in Resources */,
 				9CCA2293289BAB0F00A2F9B0 /* MockPost.json in Resources */,
 				9BE602A3289548CF008F291C /* Pretendard-SemiBold.ttf in Resources */,
 				9BE602A5289548CF008F291C /* Pretendard-Regular.ttf in Resources */,
@@ -1485,7 +1484,6 @@
 				9B61D0F728AE92F700F6DD0B /* ThemeView.swift in Sources */,
 				9B03732D28A556020089CC48 /* UIResponder + Extension.swift in Sources */,
 				9B085F032879991400DE8E60 /* NaenioApp.swift in Sources */,
-				9B19A1D528AF1E330072DEDA /* KeyValue.swift in Sources */,
 				4CC3CEAC28ABF95400458138 /* VoteResponseModel.swift in Sources */,
 				9BE60293289541B6008F291C /* Color + Extension.swift in Sources */,
 				9B19A1DD28AF7B1E0072DEDA /* AvailableNicknameResponseModel.swift in Sources */,
@@ -1497,6 +1495,7 @@
 				9C8D603B28A3746500632BCC /* UIApplication + Extension.swift in Sources */,
 				9B391A1928AB208E0007F4D6 /* HalfSheet.swift in Sources */,
 				9CBCDCD928ADE77A00C4C577 /* PostRequestInformation.swift in Sources */,
+				4C7ECFF228B518FE006C1763 /* CommentRepliesResponseModel.swift in Sources */,
 				4CC3CE9728AA8A3900458138 /* PostResponseModel.swift in Sources */,
 				9B8D409C28AE86B90024E989 /* VotesViewModel.swift in Sources */,
 				9CBCDCE328AE2A3700C4C577 /* FullView.swift in Sources */,
@@ -1565,12 +1564,14 @@
 				9BE13FF128AA5CD1009ED95D /* CustomNavigationView.swift in Sources */,
 				9BE13FED28AA5717009ED95D /* CustomNavigationBar.swift in Sources */,
 				4CC4B7342896BDE400774192 /* MainView.swift in Sources */,
+				4C7ECFF028B51755006C1763 /* CommentRepliesRequestModel.swift in Sources */,
 				9C69153628AC90EE00317489 /* LazyView.swift in Sources */,
 				9BF00C0B287ACFA900F08035 /* LoginRequestInformation.swift in Sources */,
 				4CA59EA328AE8888002C0FA9 /* CommentType.swift in Sources */,
 				9B8B98BA289948DA007336DE /* LocalStorageKeys.swift in Sources */,
 				9C3309CD2888EC52000C592F /* KakaoLoginManager.swift in Sources */,
 				9C8B5E0A289CEF000029BB66 /* MockPostGenerator.swift in Sources */,
+				4C7ECFEE28B5100B006C1763 /* KeyValue.swift in Sources */,
 				9CE311D428A6439900EDB0F4 /* CommentView.swift in Sources */,
 				4CC4B7392896BF1C00774192 /* CurationView.swift in Sources */,
 			);
@@ -1736,7 +1737,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 3;
 				DEVELOPMENT_ASSET_PATHS = "\"Naenio/Preview Content\"";
-				DEVELOPMENT_TEAM = W6QHM4Y43Z;
+				DEVELOPMENT_TEAM = KT2XM3Z9DZ;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Naenio/ignored/Info.plist;
@@ -1744,15 +1745,15 @@
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UILaunchStoryboardName = "Launch Screen.storyboard";
-				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = UIInterfaceOrientationPortrait;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = UIInterfaceOrientationPortrait;
 				INFOPLIST_KEY_UIUserInterfaceStyle = Light;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.teamVS.Naenio;
+				PRODUCT_BUNDLE_IDENTIFIER = com.yoonyoung.Naenio;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_EMIT_LOC_STRINGS = YES;
@@ -1772,7 +1773,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 3;
 				DEVELOPMENT_ASSET_PATHS = "\"Naenio/Preview Content\"";
-				DEVELOPMENT_TEAM = W6QHM4Y43Z;
+				DEVELOPMENT_TEAM = KT2XM3Z9DZ;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Naenio/ignored/Info.plist;
@@ -1780,15 +1781,15 @@
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UILaunchStoryboardName = "Launch Screen.storyboard";
-				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = UIInterfaceOrientationPortrait;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = UIInterfaceOrientationPortrait;
 				INFOPLIST_KEY_UIUserInterfaceStyle = Light;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.teamVS.Naenio;
+				PRODUCT_BUNDLE_IDENTIFIER = com.yoonyoung.Naenio;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_EMIT_LOC_STRINGS = YES;

--- a/Naenio.xcodeproj/xcuserdata/cho-yoonyoung.xcuserdatad/xcschemes/xcschememanagement.plist
+++ b/Naenio.xcodeproj/xcuserdata/cho-yoonyoung.xcuserdatad/xcschemes/xcschememanagement.plist
@@ -7,7 +7,7 @@
 		<key>Naenio.xcscheme_^#shared#^_</key>
 		<dict>
 			<key>orderHint</key>
-			<integer>12</integer>
+			<integer>13</integer>
 		</dict>
 	</dict>
 </dict>

--- a/Naenio/Sources/Curation/CurationView.swift
+++ b/Naenio/Sources/Curation/CurationView.swift
@@ -34,6 +34,7 @@ struct CurationView: View {
             .padding(.horizontal, 20)
         }
         .navigationBarHidden(true)
+        .navigationBarTitle("", displayMode: .inline)
     }
 }
 

--- a/Naenio/Sources/Home/Comment/CommentContentCell.swift
+++ b/Naenio/Sources/Home/Comment/CommentContentCell.swift
@@ -19,7 +19,7 @@ struct CommentContentCell: View {
     
     var body: some View {
         HStack(alignment: .top, spacing: 8) {
-            NavigationLink(destination: CommentRepliesView(isPresented: $isPresented, comment: comment, parentId: parentId),
+            NavigationLink(destination: CommentRepliesView(isPresented: $isPresented, comment: comment, parentId: comment.id),
                            isActive: $isNavigationActive) {
                 EmptyView()
             }

--- a/Naenio/Sources/Home/Comment/CommentRepliesView.swift
+++ b/Naenio/Sources/Home/Comment/CommentRepliesView.swift
@@ -13,7 +13,7 @@ struct CommentRepliesView: View {
     @Environment(\.presentationMode) var presentationMode: Binding<PresentationMode>
     @Binding var isPresented: Bool
     
-    @ObservedObject var viewModel = CommentViewModel()
+    @ObservedObject var viewModel = CommentRepliesViewModel()
     @ObservedObject var scrollViewHelper = ScrollViewHelper()
     
     @State var text: String = ""
@@ -103,7 +103,7 @@ struct CommentRepliesView: View {
                     WrappedTextView(placeholder: "댓글 추가", content: $text, characterLimit: 100, showLimit: false, isTight: true)
                     
                     Button(action: {
-                        viewModel.registerComment(self.text, postId: self.parentId, type: .comment)
+                        viewModel.registerReply(self.text, postId: self.parentId)
                     }) {
                         Text("게시")
                             .font(.semoBold(size: 14))
@@ -118,7 +118,7 @@ struct CommentRepliesView: View {
         }
         .navigationBarHidden(true)
         .onAppear {
-            viewModel.requestComments(isFirstRequest: true)
+            viewModel.requestCommentReplies(postId: self.parentId)
         }
     }
 }

--- a/Naenio/Sources/Home/Comment/CommentRepliesViewModel.swift
+++ b/Naenio/Sources/Home/Comment/CommentRepliesViewModel.swift
@@ -15,14 +15,93 @@ class CommentRepliesViewModel: ObservableObject {
     
     private var bag = DisposeBag()
     private let serialQueue = SerialDispatchQueueScheduler(qos: .utility)
-    let parentID = UUID().uuidString.hashValue // TODO: 나중에 밖에서 받아와야 함
 
-    @Published var commentsCount: Int?
+    private let pagingSize = 10
+    @Published var commentRepliesCount: Int?
     @Published var replies = [Comment]()
     @Published var status = Status.waiting
     
+    func registerReply(_ content: String, postId: Int?) {
+        guard let postId = postId else {
+            return
+        }
+        
+        status = .loading
+        let commentRequestModel = CommentPostRequestModel(parentID: postId, parentType: CommentType.comment.rawValue, content: content)
+        
+        RequestService<CommentPostResponseModel>.request(api: .postComment(commentRequestModel))
+            .subscribe(on: serialQueue)
+            .observe(on: MainScheduler.instance)
+            .subscribe(
+                onSuccess: { [weak self] reply in
+                    guard let self = self else { return }
+                    
+                    withAnimation {
+                        let newReply = self.transferToCommentModel(from: reply)
+                        self.replies.insert(newReply, at: 0)
+                    }
+                    
+                    self.status = .done
+                }, onFailure: { [weak self] error in
+                    guard let self = self else { return }
+                    self.status = .fail(with: error)
+                }, onDisposed: {
+                    print("Disposed registerComment")
+                })
+            .disposed(by: bag)
+    }
+    
+    func transferToCommentModel(from comment: CommentPostResponseModel) -> Comment {
+        let author = Comment.Author(id: comment.memberId, nickname: UserManager.shared.getNickName(), profileImageIndex: UserManager.shared.getProfileImagesIndex())
+        return Comment(id: comment.id, author: author, content: comment.content, createdDatetime: comment.createdDateTime, likeCount: 0, isLiked: false, repliesCount: 0)
+    }
+    
+    func transferToCommentModel(from replies: [CommentRepliesResponseModel.CommentRepliesListModel]) -> [Comment] {
+        var result: [Comment] = [ ]
+        replies.forEach { reply in
+            let author = Comment.Author(id: reply.author.id, nickname: reply.author.nickname, profileImageIndex: reply.author.profileImageIndex)
+            let newReply = Comment(id: reply.id, author: author, content: reply.content, createdDatetime: reply.createdDatetime, likeCount: reply.likeCount, isLiked: reply.isLiked, repliesCount: 0)
+            result.append(newReply)
+        }
+        
+        return result
+    }
+    
+    func requestCommentReplies(postId: Int?, isFirstRequest: Bool = true) {
+        status = .loading
+        guard let postId = postId else {
+            return
+        }
+        
+        let commentRepliesRequestModel = CommentRepliesRequestModel(size: pagingSize, lastCommentId: nil)
+        RequestService<CommentRepliesResponseModel>.request(api: .getCommentReplies(postId: postId, model: commentRepliesRequestModel))
+            .subscribe(on: self.serialQueue)
+            .observe(on: MainScheduler.instance)
+            .subscribe(
+                onSuccess: { [weak self] replies in
+                    guard let self = self else { return }
+                    print("Success requestComments")
+                    
+                    self.commentRepliesCount = replies.commentReplies.count
+                    
+                    if isFirstRequest {
+                        self.replies = self.transferToCommentModel(from: replies.commentReplies)
+                    } else {
+                        self.replies.append(contentsOf: self.transferToCommentModel(from: replies.commentReplies))
+                    }
+                    
+                    self.status = .done
+                }, onFailure: { [weak self] error in
+                    guard let self = self else { return }
+                    self.status = .fail(with: error)
+                }, onDisposed: {
+                    print("Disposed requestComments")
+                })
+            .disposed(by: bag)
+    }
+    
     // !!!: Test
-    func registerComment(_ content: String, parentID: Int) {
+    func testRegisterReply(_ content: String, parentID: Int) {
         status = .loading
         let commentRequestModel = CommentPostRequestModel(parentID: parentID, parentType: CommentType.comment.rawValue, content: content)
         
@@ -49,7 +128,7 @@ class CommentRepliesViewModel: ObservableObject {
     }
     
     // !!!: Test
-    func requestComments() {
+    func testRequestCommentReplies() {
         status = .loading
         
         // ???: 얘는 잘 하면 추상화 가능할 수도(HomeViewModel이랑 똑같음 구조는)
@@ -61,7 +140,7 @@ class CommentRepliesViewModel: ObservableObject {
                     guard let self = self else { return }
                     print("Success requestComments")
                     
-                    self.commentsCount = commentInfo.totalCommentCount
+                    self.commentRepliesCount = commentInfo.totalCommentCount
                     self.replies.append(contentsOf: commentInfo.comments)
                     
                     self.status = .done

--- a/Naenio/Sources/Home/Comment/CommentView.swift
+++ b/Naenio/Sources/Home/Comment/CommentView.swift
@@ -109,7 +109,7 @@ struct CommentView: View {
                         WrappedTextView(placeholder: "댓글 추가", content: $text, characterLimit: 100, showLimit: false, isTight: true)
                         
                         Button(action: {
-                            viewModel.registerComment(self.text, postId: self.parentId, type: .post)
+                            viewModel.registerComment(self.text, postId: self.parentId)
                             UIApplication.shared.endEditing()
                             text = ""
                         }) {
@@ -129,8 +129,7 @@ struct CommentView: View {
             .navigationBarHidden(true)
         }
         .onAppear {
-            viewModel.postId = self.parentId
-            viewModel.requestComments(isFirstRequest: true)
+            viewModel.requestComments(postId: self.parentId, isFirstRequest: true)
 
             viewModel.isFirstRequest = true
         }

--- a/Naenio/Sources/Home/Comment/CommentViewModel.swift
+++ b/Naenio/Sources/Home/Comment/CommentViewModel.swift
@@ -22,7 +22,6 @@ class CommentViewModel: ObservableObject {
     @Published var status = Status.waiting
     @Published var lastCommentId: Int?
     
-    @Published var postId: Int?
     @Published var isFirstRequest: Bool = true
     
     func transferToCommentModel(_ comment: CommentPostResponseModel) -> Comment {
@@ -30,13 +29,13 @@ class CommentViewModel: ObservableObject {
         return Comment(id: comment.id, author: author, content: comment.content, createdDatetime: comment.createdDateTime, likeCount: 0, isLiked: false, repliesCount: 0)
     }
 
-    func registerComment(_ content: String, postId: Int?, type: CommentType) {
+    func registerComment(_ content: String, postId: Int?) {
         guard let postId = postId else {
             return
         }
         
         status = .loading
-        let commentRequestModel = CommentPostRequestModel(parentID: postId, parentType: type.rawValue, content: content)
+        let commentRequestModel = CommentPostRequestModel(parentID: postId, parentType: CommentType.post.rawValue, content: content)
         
         RequestService<CommentPostResponseModel>.request(api: .postComment(commentRequestModel))
             .subscribe(on: serialQueue)
@@ -60,14 +59,14 @@ class CommentViewModel: ObservableObject {
             .disposed(by: bag)
     }
     
-    func requestComments(isFirstRequest: Bool = true) {
+    func requestComments(postId: Int?, isFirstRequest: Bool = true) {
         status = .loading
-        guard let postId = self.postId else {
+        guard let postID = postId else {
             return
         }
         
         let commentListRequestModel = CommentListRequestModel(size: pageSize, lastCommentId: isFirstRequest ? nil : lastCommentId)
-        RequestService<CommentModel>.request(api: .getComment(postId: postId, model: commentListRequestModel))
+        RequestService<CommentModel>.request(api: .getComment(postId: postID, model: commentListRequestModel))
             .subscribe(on: self.serialQueue)
             .observe(on: MainScheduler.instance)
             .subscribe(

--- a/Naenio/Sources/Home/Comment/Model/CommentRepliesRequestModel.swift
+++ b/Naenio/Sources/Home/Comment/Model/CommentRepliesRequestModel.swift
@@ -1,0 +1,13 @@
+//
+//  CommentRepliesRequestModel.swift
+//  Naenio
+//
+//  Created by 조윤영 on 2022/08/23.
+//
+
+import Foundation
+
+struct CommentRepliesRequestModel: ModelType {
+    var size: Int
+    var lastCommentId: Int?
+}

--- a/Naenio/Sources/Home/Comment/Model/CommentRepliesResponseModel.swift
+++ b/Naenio/Sources/Home/Comment/Model/CommentRepliesResponseModel.swift
@@ -1,0 +1,21 @@
+//
+//  CommentRepliesResponseModel.swift
+//  Naenio
+//
+//  Created by 조윤영 on 2022/08/23.
+//
+
+import Foundation
+
+struct CommentRepliesResponseModel: ModelType {
+    var commentReplies: [CommentRepliesListModel]
+    
+    struct CommentRepliesListModel: ModelType {
+        var id: Int
+        var author: Author
+        var content: String
+        var createdDatetime: String
+        var likeCount: Int
+        var isLiked: Bool
+    }
+}

--- a/Naenio/Sources/Home/HomeView.swift
+++ b/Naenio/Sources/Home/HomeView.swift
@@ -127,6 +127,7 @@ struct HomeView: View {
                     .padding(20)
             }
             .navigationBarHidden(true)
+            .navigationBarTitle("", displayMode: .inline)
             .fullScreenCover(isPresented: $showNewPost) {
                 NewPostView(isPresented: $showNewPost)
                     .environmentObject(viewModel)

--- a/Naenio/Sources/Home/HomeViewModel.swift
+++ b/Naenio/Sources/Home/HomeViewModel.swift
@@ -83,7 +83,7 @@ class HomeViewModel: ObservableObject {
         bag = DisposeBag()
         status = .loading(reason: "sameCategoryPosts")
         
-        let feedRequestInformation: FeedRequestInformation = FeedRequestInformation(size: pagingSize, lastPostId: 10, sortType: sortType?.rawValue)
+        let feedRequestInformation: FeedRequestInformation = FeedRequestInformation(size: pagingSize, lastPostId: self.lastPostId, sortType: sortType?.rawValue)
 
         RequestService<FeedResponseModel>.request(api: .getFeed(feedRequestInformation))
             .subscribe(on: self.serialQueue)

--- a/Naenio/Utils/Network/API/NaenioAPI+Method.swift
+++ b/Naenio/Utils/Network/API/NaenioAPI+Method.swift
@@ -9,7 +9,7 @@ extension NaenioAPI {
     func getMehod() -> Moya.Method {
         switch self {
         case .signOut, .withDrawal, .login, .postPost, .postVote, .postComment: return .post
-        case .getUser, .getFeed, .getTheme, .getComment, .getSinglePost, .getIsNicknameAvailable: return .get
+        case .getUser, .getFeed, .getTheme, .getComment, .getCommentReplies, .getSinglePost, .getIsNicknameAvailable: return .get
         case .putNickname, .putProfileIndex: return .put
         }
     }

--- a/Naenio/Utils/Network/API/NaenioAPI+Path.swift
+++ b/Naenio/Utils/Network/API/NaenioAPI+Path.swift
@@ -21,11 +21,11 @@ extension NaenioAPI {
         case .getUser: return "app/members/me"
         case .getFeed: return "/app/feed"
         case .getComment(let postId, _): return "/app/posts/\(postId)/comments"
+        case .getCommentReplies(let postId, _): return "/app/comments/\(postId)/comment-replies"
         case .getSinglePost(let info): return "/app/posts/\(info.id)"
         case .getIsNicknameAvailable(let nickname): return "/app/members/exist?nickname=\(nickname)"
-            
-        case .putNickname(let nickname): return "/app/members/nickname"
-        case .putProfileIndex(let index): return "/app/members/profile-image"
+        case .putNickname: return "/app/members/nickname"
+        case .putProfileIndex: return "/app/members/profile-image"
         }
     }
 }

--- a/Naenio/Utils/Network/API/NaenioAPI+Task.swift
+++ b/Naenio/Utils/Network/API/NaenioAPI+Task.swift
@@ -31,7 +31,9 @@ extension NaenioAPI {
             return .requestParameters(parameters: request.toDictionary(), encoding: URLEncoding.default)
         case .getTheme(let request):
             return .requestParameters(parameters: request.toDictionary(), encoding: URLEncoding.default)
-        case .getComment(let _, let model):
+        case .getComment( _, let model):
+            return .requestParameters(parameters: model.toDictionary(), encoding: URLEncoding.default)
+        case .getCommentReplies(_, let model):
             return .requestParameters(parameters: model.toDictionary(), encoding: URLEncoding.default)
         case .getIsNicknameAvailable(let request):
             return .requestParameters(parameters: request.toDictionary(), encoding: URLEncoding.default)

--- a/Naenio/Utils/Network/API/NaenioAPI.swift
+++ b/Naenio/Utils/Network/API/NaenioAPI.swift
@@ -6,7 +6,6 @@
 //
 /*
  API endpoint 케이스 정의
- //TODO: API 명세서 확정될 시,URI 및 request 형식 변경
  */
 
 import Moya
@@ -23,6 +22,7 @@ enum NaenioAPI {
     case getUser(String)
     case getFeed(FeedRequestInformation)
     case getComment(postId: Int, model: CommentListRequestModel)
+    case getCommentReplies(postId: Int, model: CommentRepliesRequestModel)
     case getTheme(ThemeRequestModel)
     case getSinglePost(SinglePostRequestInformation)
     case getIsNicknameAvailable(String)


### PR DESCRIPTION
## 개요
대댓글 조회 API 연결 및 기타사항 수정
> /app/comments/{id}/comment-replies

```
endpoint: Wrapper(base: Naenio.NaenioAPI.getCommentReplies(postId: 244, model: Naenio.CommentRepliesRequestModel(size: 10, lastCommentId: nil)))
REQUEST: HTTPMethod(rawValue: "GET") https://teamversus.shop /app/comments/244/comment-replies /Users/cho-yoonyoung/Naenio-iOS-dev/Naenio/Utils/Network/Service/RequestService.swift request(api:) 11
🛰 SUCCESS: HTTPMethod(rawValue: "GET") https://teamversus.shop /app/comments/244/comment-replies (200) /Users/cho-yoonyoung/Naenio-iOS-dev/Naenio/Utils/Network/Service/RequestService.swift request(api:) 11
Success requestComments
Disposed requestComments
```

## 작업 내용
- [x] 대댓글 조회 API 연결
- [x] 대댓글 생성 APi 확인 
- [x] 탭뷰 화면 상단에 navigation bar 공간 생김 현상 수정
- [x] 기타 버그 수정

## 참고 사항
말씀해주신 내용 참고하여 대댓글이 독립적인 viewModel을 가질 수 있도록 수정했습니다.

// TODO: 댓글 및 대댓글 작성 시, 리스트 자동 갱신되도록 수정 필요
